### PR TITLE
Add composite Overview tab to the viewer

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -42,7 +42,10 @@
     <img id="mapImage" class="map" alt="Map" src="" />
   </div>
 
+  <div class="overview" id="overviewContainer"></div>
+
   <script src="viewer_config.js"></script>
+  <script src="js/overview.js"></script>
   <script src="js/mapView.js"></script>
   <script src="js/keyboard.js"></script>
   <script src="js/main.js"></script>

--- a/viewer/js/mapView.js
+++ b/viewer/js/mapView.js
@@ -4,54 +4,149 @@ let currentPlanet = null;
 let zoomStepIndex = 0;
 let scale = 1, offsetX = 0, offsetY = 0;
 
+/**
+ * Zoom multiplier for an overview side cell, relative to its "fill the cell"
+ * baseline. Read from viewerConfig.defaultZoom; a missing entry means 1x.
+ * (Planet tabs are left at the upstream default and don't use this.)
+ */
+function getZoomMultiplier(planet) {
+  const cfg = viewerConfig.defaultZoom || {};
+  const value = planet in cfg ? cfg[planet] : cfg.default;
+  if (value === undefined || value === "fit") return 1;
+  return value;
+}
+
+/**
+ * Persists the current pan/zoom for the active planet, but only when it is
+ * actually being displayed (a visible, loaded image). This avoids caching a
+ * bogus layout computed while the single-map view was hidden behind the
+ * overview.
+ */
+function saveCurrentState(mapImage) {
+  const container = mapImage.parentElement;
+  const visible = container && container.offsetParent !== null;
+  if (currentPlanet && visible && mapImage.complete && mapImage.naturalWidth > 0) {
+    statePerPlanet[currentPlanet] = { zoomStepIndex, offsetX, offsetY };
+  }
+}
+
 function setupTabs(previewSources, tabContainer, mapImage) {
-  Object.entries(previewSources).forEach(([planet, url], index) => {
+  const overviewEl = document.getElementById("overviewContainer");
+  const hasOverview = overviewEl && buildOverview(previewSources, overviewEl);
+
+  if (hasOverview) {
+    const overviewTab = document.createElement("div");
+    overviewTab.className = "tab";
+    overviewTab.dataset.view = "overview";
+    overviewTab.textContent = "Overview";
+    overviewTab.addEventListener("click", () => activateOverview(mapImage));
+    tabContainer.appendChild(overviewTab);
+  }
+
+  const planetKeys = Object.keys(previewSources);
+  planetKeys.forEach((planet) => {
     const tab = document.createElement("div");
     tab.className = "tab";
     tab.dataset.planet = planet;
     tab.textContent = planet.charAt(0).toUpperCase() + planet.slice(1);
-
-    if (index === 0) {
-      tab.classList.add("active");
-      currentPlanet = planet;
-
-      const fallback = document.createElement("div");
-      fallback.textContent = "🚫 No preview available yet for this planet.";
-      fallback.style.cssText = "color: white; padding: 1em; text-align: center;";
-      fallback.style.display = "none";
-      mapImage.parentElement.appendChild(fallback);
-
-      mapImage.onerror = () => {
-        console.error("Failed to load map image:", mapImage.src);
-        mapImage.style.display = "none";
-        fallback.style.display = "block";
-      };
-
-      mapImage.onload = () => {
-        mapImage.style.display = "block";
-        fallback.style.display = "none";
-      };
-
-      mapImage.src = url;
-    }
-
     tab.addEventListener("click", () => switchPlanet(planet, previewSources, mapImage));
     tabContainer.appendChild(tab);
   });
+
+  setupMapImageHandlers(mapImage);
+
+  // Select the configured default tab. Loading of the single-map image is
+  // deferred until a planet tab is actually opened (see switchPlanet) so it
+  // never lays out against a hidden, zero-size container.
+  const target = resolveDefaultTab(hasOverview, planetKeys);
+  if (target === "overview") {
+    activateOverview(mapImage);
+  } else if (target) {
+    switchPlanet(target, previewSources, mapImage);
+  }
+}
+
+/**
+ * Sets up the single-map <img> load/error handling and its "no preview"
+ * fallback, once, independent of which tab is shown first.
+ */
+function setupMapImageHandlers(mapImage) {
+  const fallback = document.createElement("div");
+  fallback.textContent = "🚫 No preview available yet for this planet.";
+  fallback.style.cssText = "color: white; padding: 1em; text-align: center;";
+  fallback.style.display = "none";
+  mapImage.parentElement.appendChild(fallback);
+
+  mapImage.onerror = () => {
+    console.error("Failed to load map image:", mapImage.src);
+    mapImage.style.display = "none";
+    fallback.style.display = "block";
+  };
+  mapImage.onload = () => {
+    mapImage.style.display = "block";
+    fallback.style.display = "none";
+  };
+}
+
+/**
+ * Resolves viewerConfig.defaultTab to an actual target ("overview" or a
+ * planet name), falling back to the overview (or first planet) when the
+ * requested tab isn't available.
+ */
+function resolveDefaultTab(hasOverview, planetKeys) {
+  const fallback = hasOverview ? "overview" : (planetKeys[0] || null);
+  const pref = viewerConfig.defaultTab || "auto";
+  if (pref === "auto" || pref === "overview") return fallback;
+  return planetKeys.includes(pref) ? pref : fallback;
+}
+
+function setViewControlsVisible(visible) {
+  const display = visible ? "" : "none";
+  const zoomDisplay = document.getElementById("zoomDisplay");
+  const resetBtn = document.getElementById("resetView");
+  if (zoomDisplay) zoomDisplay.style.display = display;
+  if (resetBtn) resetBtn.style.display = display;
+}
+
+function activateOverview(mapImage) {
+  saveCurrentState(mapImage);
+
+  document.querySelectorAll(".tab").forEach(tab => tab.classList.remove("active"));
+  const overviewTab = document.querySelector('.tab[data-view="overview"]');
+  if (overviewTab) overviewTab.classList.add("active");
+
+  mapImage.parentElement.style.display = "none";
+  const overviewEl = document.getElementById("overviewContainer");
+  if (overviewEl) overviewEl.style.display = "grid";
+  setViewControlsVisible(false);
+
+  // Cells need their size to lay out; they were hidden until now.
+  initOverviewCells(false);
 }
 
 function switchPlanet(planet, previewSources, mapImage) {
-  if (currentPlanet) {
-    statePerPlanet[currentPlanet] = { zoomStepIndex, offsetX, offsetY };
-  }
+  saveCurrentState(mapImage);
+
+  const overviewEl = document.getElementById("overviewContainer");
+  if (overviewEl) overviewEl.style.display = "none";
+  mapImage.parentElement.style.display = "";
+  setViewControlsVisible(true);
 
   document.querySelectorAll(".tab").forEach(tab => tab.classList.remove("active"));
   const newTab = document.querySelector(`.tab[data-planet="${planet}"]`);
   if (newTab) newTab.classList.add("active");
 
+  const targetUrl = previewSources[planet];
+  const needLoad = mapImage.getAttribute("src") !== targetUrl;
   currentPlanet = planet;
-  mapImage.src = previewSources[planet];
-  mapImage.onerror = () => console.error("Failed to load map image:", mapImage.src);
+
+  if (needLoad) {
+    mapImage.src = targetUrl; // triggers the load handler -> handleImageLoad
+  } else {
+    // Image is already loaded (e.g. reopening Nauvis): no load event will
+    // fire, so recompute the layout now that the container is visible.
+    handleImageLoad(mapImage, mapContainer, zoomDisplay);
+  }
 }
 
 function handleImageLoad(mapImage, container, zoomDisplay) {

--- a/viewer/js/overview.js
+++ b/viewer/js/overview.js
@@ -1,0 +1,157 @@
+/**
+ * Builds the composite "Overview" layout: one large planet on the left
+ * (~2/3 width) and the remaining planets stacked top-to-bottom on the
+ * right (~1/3 width). Each cell is an independent pan/zoom viewport.
+ *
+ * The main planet (Nauvis) opens at the upstream planet-tab setting (100%,
+ * native pixels) so it matches its own tab. The side planets open at their
+ * configured zoom (viewerConfig.defaultZoom) relative to a "fill the cell"
+ * baseline.
+ */
+const OVERVIEW_MAX_ZOOM_FACTOR = 16; // how far past "fill" a cell may be zoomed
+let overviewCells = [];
+
+function buildOverview(previewSources, overviewEl) {
+  const cfg = viewerConfig.overview;
+  const availableSide = ((cfg && cfg.side) || []).filter((planet) => previewSources[planet]);
+
+  // Skip the overview entirely when it would only contain the main planet
+  // (e.g. vanilla / non-Space-Age maps that expose just Nauvis).
+  if (!cfg || !cfg.main || !previewSources[cfg.main] || availableSide.length === 0) {
+    return false;
+  }
+
+  overviewEl.innerHTML = "";
+  overviewCells = [];
+
+  overviewEl.appendChild(makeOverviewCell(cfg.main, previewSources[cfg.main], "overview-main", "native"));
+
+  const side = document.createElement("div");
+  side.className = "overview-side";
+  availableSide.forEach((planet) => {
+    side.appendChild(makeOverviewCell(planet, previewSources[planet], "overview-cell", "fill"));
+  });
+  overviewEl.appendChild(side);
+  return true;
+}
+
+/**
+ * (Re)initializes every overview cell's default view. Called when the
+ * overview becomes visible and on resize. Cells keep the user's zoom/pan
+ * across tab switches; `force` re-centers them (used on resize).
+ */
+function initOverviewCells(force) {
+  overviewCells.forEach((cell) => cell.init(force));
+}
+
+window.addEventListener("resize", () => initOverviewCells(true));
+
+function makeOverviewCell(planet, url, className, baseMode) {
+  const zoomMultiplier = getZoomMultiplier(planet);
+
+  const cell = document.createElement("div");
+  cell.className = className;
+
+  const img = document.createElement("img");
+  img.alt = planet;
+  img.draggable = false;
+
+  const label = document.createElement("span");
+  label.className = "overview-label";
+  label.textContent = planet.charAt(0).toUpperCase() + planet.slice(1);
+
+  cell.appendChild(img);
+  cell.appendChild(label);
+
+  const state = { scale: 1, x: 0, y: 0, cover: 1, cw: 0, ch: 0, loaded: false, ready: false };
+
+  const apply = () => {
+    img.style.transform = `translate(${state.x}px, ${state.y}px) scale(${state.scale})`;
+  };
+
+  // Keep the image covering the cell so no dead space appears.
+  const clamp = () => {
+    const iw = img.naturalWidth * state.scale;
+    const ih = img.naturalHeight * state.scale;
+    state.x = Math.min(0, Math.max(state.cw - iw, state.x));
+    state.y = Math.min(0, Math.max(state.ch - ih, state.y));
+  };
+
+  const init = (force) => {
+    const w = cell.clientWidth;
+    const h = cell.clientHeight;
+    if (!state.loaded || w === 0 || h === 0) return;
+    if (state.ready && !force && w === state.cw && h === state.ch) return;
+
+    state.cw = w;
+    state.ch = h;
+    state.cover = Math.max(w / img.naturalWidth, h / img.naturalHeight);
+    // "native" mirrors the upstream planet tab (100%, native pixels); "fill"
+    // fills the cell and applies the planet's configured zoom multiplier.
+    state.scale = baseMode === "native" ? 1 : state.cover * zoomMultiplier;
+    state.x = (w - img.naturalWidth * state.scale) / 2;
+    state.y = (h - img.naturalHeight * state.scale) / 2;
+    clamp();
+    apply();
+    state.ready = true;
+  };
+
+  img.addEventListener("load", () => {
+    state.loaded = true;
+    init(true);
+  });
+  img.src = url;
+
+  cell.addEventListener(
+    "wheel",
+    (e) => {
+      if (!state.ready) return;
+      e.preventDefault();
+      const rect = cell.getBoundingClientRect();
+      const px = e.clientX - rect.left;
+      const py = e.clientY - rect.top;
+      const mx = (px - state.x) / state.scale;
+      const my = (py - state.y) / state.scale;
+
+      const factor = e.deltaY < 0 ? 1.14 : 1 / 1.14;
+      const min = state.cover;
+      const max = state.cover * OVERVIEW_MAX_ZOOM_FACTOR;
+      const ns = Math.min(max, Math.max(min, state.scale * factor));
+
+      state.x = px - mx * ns;
+      state.y = py - my * ns;
+      state.scale = ns;
+      clamp();
+      apply();
+    },
+    { passive: false }
+  );
+
+  let dragging = false;
+  let sx = 0;
+  let sy = 0;
+  cell.addEventListener("pointerdown", (e) => {
+    if (!state.ready) return;
+    dragging = true;
+    sx = e.clientX - state.x;
+    sy = e.clientY - state.y;
+    cell.setPointerCapture(e.pointerId);
+    cell.style.cursor = "grabbing";
+  });
+  cell.addEventListener("pointermove", (e) => {
+    if (!dragging) return;
+    state.x = e.clientX - sx;
+    state.y = e.clientY - sy;
+    clamp();
+    apply();
+  });
+  const endDrag = () => {
+    dragging = false;
+    cell.style.cursor = "grab";
+  };
+  cell.addEventListener("pointerup", endDrag);
+  cell.addEventListener("pointercancel", endDrag);
+
+  overviewCells.push({ init });
+  return cell;
+}

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -146,3 +146,60 @@ body {
   max-height: none;
   transform-origin: top left;
 }
+
+/* Composite "Overview" layout: main planet (~2/3) + stacked side (~1/3). */
+.overview {
+  display: none; /* toggled to "grid" by the viewer when active */
+  grid-template-columns: 2fr 1fr;
+  gap: 4px;
+  width: calc(100vw - 8px);
+  height: calc(100vh - 50px);
+  margin: 4px;
+  background-color: black;
+  box-sizing: border-box;
+}
+
+.overview-side {
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  gap: 4px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.overview-main,
+.overview-cell {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background-color: black;
+  cursor: grab;
+}
+
+.overview-main img,
+.overview-cell img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+  max-width: none;
+  max-height: none;
+  user-select: none;
+  -webkit-user-drag: none;
+  user-drag: none;
+}
+
+.overview-label {
+  position: absolute;
+  bottom: 6px;
+  left: 6px;
+  padding: 1px 5px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: var(--tab-text-active);
+  background-color: rgba(0, 0, 0, 0.45);
+  border-radius: 2px;
+  pointer-events: none;
+}

--- a/viewer/viewer_config.js
+++ b/viewer/viewer_config.js
@@ -6,5 +6,28 @@ const viewerConfig  = {
     fulgora: "../previews/fulgora.png",
     aquilo: "../previews/aquilo.png"
   },
+  // Composite "Overview" tab: one large planet on the left (~2/3 width),
+  // the rest stacked top-to-bottom on the right (~1/3 width). The Overview
+  // tab is shown only when at least one of these side planets is available
+  // (i.e. it is skipped for vanilla / non-Space-Age maps).
+  overview: {
+    main: "nauvis",
+    side: ["gleba", "fulgora", "vulcanus", "aquilo"]
+  },
+
+  // Tab selected on load: "overview", a planet name (e.g. "nauvis"), or
+  // "auto" (overview when available, otherwise the first planet). Falls back
+  // gracefully when the requested tab isn't available.
+  defaultTab: "overview",
+
+  // Zoom for the overview's side cells, as a multiple of the "fill the cell"
+  // baseline (1 = just fill, higher = zoom in). `default` applies to any side
+  // planet not listed here. Planet tabs and the overview's main planet
+  // (Nauvis) stay at the upstream default and are not affected by this.
+  defaultZoom: {
+    default: 1.5,
+    aquilo: 3
+  },
+
   planetNamesSource: "../previews/local_planet_names.js"
 };


### PR DESCRIPTION
Adds an "Overview" tab that shows the main planet (Nauvis) on the left ~2/3 of the screen with the Space Age planets (Gleba, Fulgora, Vulcanus, Aquilo) stacked on the right ~1/3. Each cell is an independent pan/zoom viewport clamped so no dead space appears.

- Overview Nauvis cell renders at native 100% to match the Nauvis tab; side cells open at a configurable zoom over a "fill the cell" baseline (viewerConfig.defaultZoom: 1.5x default, 3x Aquilo).
- Planet tabs are left exactly at the upstream scale/centering; per-planet zoom applies only inside the overview.
- Default tab is configurable (viewerConfig.defaultTab); the Overview tab is skipped for vanilla / non-Space-Age maps that expose only Nauvis.
- Defer the single-map image load until a planet tab is opened and recompute layout when it becomes visible, fixing the Nauvis tab mispositioning.